### PR TITLE
Fixed the attachment bug. The contents of the attachment were being read...

### DIFF
--- a/standalone-mailer/mailed.js
+++ b/standalone-mailer/mailed.js
@@ -52,7 +52,7 @@
   forEachAsync(attachment, function (next, attach) {
     var data;
     
-    data = fs.readFileSync(attach, 'utf8');
+    data = fs.readFileSync(attach);
     attachments.push({
         "filename": attach.split('/').pop()
       , "contents": data


### PR DESCRIPTION
... in with 'utf8' encoding, which causes binary attachments to become corrupted. Now the function readFileSync should be reading in the attachment contents as a Buffer (binary).
